### PR TITLE
이슈 생성 및 사이드 메뉴

### DIFF
--- a/backend/models/label.js
+++ b/backend/models/label.js
@@ -5,11 +5,11 @@ module.exports = class Label extends Sequelize.Model {
     return super.init(
       {
         title: {
-          type: Sequelize.STRING(30),
+          type: Sequelize.STRING(50),
           allowNull: false,
         },
         description: {
-          type: Sequelize.STRING(30),
+          type: Sequelize.STRING(100),
           allowNull: true,
         },
         color: {

--- a/backend/routes/allData.js
+++ b/backend/routes/allData.js
@@ -46,11 +46,11 @@ router.get('/', async (req, res) => {
       }),
       db.label.findAll({
         where: { issueTrackerId },
-        attributes: ['title', 'description', 'color'],
+        attributes: ['id', 'title', 'description', 'color'],
       }),
       db.milestone.findAll({
         where: { issueTrackerId },
-        attributes: ['title', 'description', 'status', 'dueDate'],
+        attributes: ['id', 'title', 'description', 'status', 'dueDate'],
       }),
       db.joinUser.findAll({
         where: { issueTrackerId },

--- a/frontend/public/reset.css
+++ b/frontend/public/reset.css
@@ -9,3 +9,7 @@ body {
   margin: 0;
   box-sizing: border-box;
 }
+
+li {
+  list-style-type: none;
+}

--- a/frontend/src/components/AsideMenu/AssigneeMenu.jsx/Assignee/index.js
+++ b/frontend/src/components/AsideMenu/AssigneeMenu.jsx/Assignee/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+export const Assignee = ({ assignee }) => {
+  return <li>{assignee.User.username}</li>;
+};
+
+export const DropDownJoinUser = ({
+  additionalInfo,
+  joinUser,
+  setAdditionalInfo
+}) => {
+  const isSelected = additionalInfo.assignees.some(
+    selectedAssignee => selectedAssignee.id === joinUser.User.id
+  );
+  const clickAssignee = () => {
+    if (!isSelected) {
+      return setAdditionalInfo({
+        ...additionalInfo,
+        assignees: [...additionalInfo.assignees, joinUser]
+      });
+    }
+    const remainAssignees = additionalInfo.assignees.filter(
+      assignee => assignee.User.id != joinUser.User.id
+    );
+    setAdditionalInfo({ ...additionalInfo, assignees: remainAssignees });
+  };
+
+  return (
+    <li onClick={clickAssignee}>
+      {isSelected && (
+        <span>
+          <i className='fas fa-check'></i>
+        </span>
+      )}
+      {/* <img src={joinUser.User.profileImage} alt='profile'></img> |{' '} */}
+      {joinUser.User.username}
+    </li>
+  );
+};

--- a/frontend/src/components/AsideMenu/AssigneeMenu.jsx/index.jsx
+++ b/frontend/src/components/AsideMenu/AssigneeMenu.jsx/index.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Assignee, DropDownJoinUser } from './Assignee';
+import useInputChange from '../../../hooks/useInputChange';
+import { useMainState } from '../../../contexts/MainContext';
+import { AssigneeContainer, AssigneeDropDownContainer } from './style';
+import Filter from '../../common/Filter';
+
+export const AssigneeMenu = ({ additionalInfo, onClick }) => {
+  return (
+    <AssigneeContainer>
+      <div className='assignee_header'>
+        <div className='assignee_title'>Assignees</div>
+        <div className='setting_btn' onClick={onClick}>
+          <i className='fas fa-cog'></i>
+        </div>
+      </div>
+      <ul>
+        {additionalInfo.assignees.length ? (
+          additionalInfo.assignees.map(assignee => (
+            <Assignee key={assignee.id} assignee={assignee} />
+          ))
+        ) : (
+          <li>No one - assign yourself</li>
+        )}
+      </ul>
+    </AssigneeContainer>
+  );
+};
+
+export const AssigneeMenuDropDown = ({ additionalInfo, setAdditionalInfo }) => {
+  const [username, changeUsername] = useInputChange('');
+  const { joinUsers } = useMainState();
+
+  return (
+    <AssigneeDropDownContainer>
+      <div className='assign_title'>Assign up to 10 people to this issue</div>
+      <Filter
+        value={username}
+        onChange={changeUsername}
+        placeholder='Type or choose a name'
+      />
+      <ul>
+        {joinUsers.map(joinUser => (
+          <DropDownJoinUser
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+            key={joinUser.User.id}
+            joinUser={joinUser}
+          />
+        ))}
+      </ul>
+    </AssigneeDropDownContainer>
+  );
+};

--- a/frontend/src/components/AsideMenu/AssigneeMenu.jsx/style.js
+++ b/frontend/src/components/AsideMenu/AssigneeMenu.jsx/style.js
@@ -1,0 +1,26 @@
+import styled from '@emotion/styled';
+
+export const AssigneeContainer = styled.section`
+  position: relative;
+
+  & .assignee_header {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  & .assignee_title {
+    font-weight: bold;
+  }
+`;
+
+export const AssigneeDropDownContainer = styled.section`
+  position: absolute;
+  width: 15rem;
+  bottom: 0;
+  background-color: lightblue;
+  border: 1px solid blue;
+
+  & .assign_title {
+    font-size: 13px;
+  }
+`;

--- a/frontend/src/components/AsideMenu/LabelMenu.jsx/Label/index.jsx
+++ b/frontend/src/components/AsideMenu/LabelMenu.jsx/Label/index.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { LabelContainer, DropDownLabelContainer } from './style';
+
+export const Label = ({ label }) => {
+  return (
+    <LabelContainer color={label.color}>
+      <div>{label.title}</div>
+    </LabelContainer>
+  );
+};
+
+export const DropDownLabel = ({ label, additionalInfo, setAdditionalInfo }) => {
+  const isSelected = additionalInfo.labels.some(
+    selectedLabel => selectedLabel.id === label.id
+  );
+
+  const clickLabel = () => {
+    if (isSelected) {
+      const withoutSelected = additionalInfo.labels.filter(
+        selectedLabel => selectedLabel.id != label.id
+      );
+      setAdditionalInfo({ ...additionalInfo, labels: withoutSelected });
+    } else {
+      setAdditionalInfo({
+        ...additionalInfo,
+        labels: [...additionalInfo.labels, label]
+      });
+    }
+  };
+
+  return (
+    <DropDownLabelContainer onClick={clickLabel}>
+      <div>{isSelected ? 'O' : 'X'}</div>
+      <div>{label.color}</div>
+      <div>{label.title}</div>
+      <div>{label.description}</div>
+    </DropDownLabelContainer>
+  );
+};

--- a/frontend/src/components/AsideMenu/LabelMenu.jsx/Label/style.js
+++ b/frontend/src/components/AsideMenu/LabelMenu.jsx/Label/style.js
@@ -1,0 +1,9 @@
+import styled from '@emotion/styled';
+
+export const LabelContainer = styled.li`
+  display: flex;
+`;
+
+export const DropDownLabelContainer = styled.li`
+  display: flex;
+`;

--- a/frontend/src/components/AsideMenu/LabelMenu.jsx/index.jsx
+++ b/frontend/src/components/AsideMenu/LabelMenu.jsx/index.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { useMainState } from '../../../contexts/MainContext';
+import { LabelMenuContainer, LabelMenuDropDownContainer } from './style';
+import { Label, DropDownLabel } from './Label';
+import Filter from '../../common/Filter';
+import useInputChange from '../../../hooks/useInputChange';
+
+export const LabelMenu = ({ additionalInfo, setAdditionalInfo, onClick }) => {
+  return (
+    <LabelMenuContainer>
+      <div className='label_header'>
+        <div className='label_title'>Labels</div>
+        <div className='label_setting_btn' onClick={onClick}>
+          <i className='fas fa-cog'></i>
+        </div>
+      </div>
+      <ul className='label_selected'>
+        {additionalInfo.labels.length ? (
+          additionalInfo.labels.map(label => (
+            <Label key={label.id} label={label}></Label>
+          ))
+        ) : (
+          <li>None yet</li>
+        )}
+      </ul>
+    </LabelMenuContainer>
+  );
+};
+
+export const LabelMenuDropDown = ({ additionalInfo, setAdditionalInfo }) => {
+  const { labels } = useMainState();
+  const [labelTitle, changeLabelTitle] = useInputChange('');
+
+  return (
+    <LabelMenuDropDownContainer additionalInfo={additionalInfo}>
+      <div>Apply labels to this issue</div>
+      <Filter
+        value={labelTitle}
+        onChange={changeLabelTitle}
+        placeholder='Filter labels'
+      />
+      <ul>
+        {labels.length ? (
+          labels.map(label => (
+            <DropDownLabel
+              key={label.id}
+              label={label}
+              additionalInfo={additionalInfo}
+              setAdditionalInfo={setAdditionalInfo}
+            />
+          ))
+        ) : (
+          <div>No Labels</div>
+        )}
+      </ul>
+    </LabelMenuDropDownContainer>
+  );
+};

--- a/frontend/src/components/AsideMenu/LabelMenu.jsx/style.js
+++ b/frontend/src/components/AsideMenu/LabelMenu.jsx/style.js
@@ -1,0 +1,30 @@
+import styled from '@emotion/styled';
+
+export const LabelMenuContainer = styled.section`
+  position: relative;
+
+  & .label_header {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  & .label_title {
+    font-weight: bold;
+  }
+
+  & .label_setting_btn {
+  }
+
+  & .label_selected {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+`;
+
+export const LabelMenuDropDownContainer = styled.section`
+  position: absolute;
+  bottom: 0;
+  background-color: lightblue;
+  border: 1px solid blue;
+`;

--- a/frontend/src/components/AsideMenu/MilestoneMenu/Milestone/index.jsx
+++ b/frontend/src/components/AsideMenu/MilestoneMenu/Milestone/index.jsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import { MilestoneItem } from './style';
+
+const Milestone = ({ milestone, additionalInfo, setAdditionalInfo }) => {
+  const isSelected =
+    additionalInfo.milestone && additionalInfo.milestone.id === milestone.id;
+
+  const clickMilestone = () => {
+    if (isSelected) {
+      setAdditionalInfo({ ...additionalInfo, milestone: null });
+      return;
+    }
+    setAdditionalInfo({ ...additionalInfo, milestone });
+  };
+
+  return (
+    <MilestoneItem onClick={clickMilestone}>
+      {isSelected && (
+        <div>
+          <i className='fas fa-check'></i>
+        </div>
+      )}
+      <section>
+        <div className='milestone-title'>{milestone.title}</div>
+        <div className='milestone-duedate'>
+          {milestone.dueDate ? `${milestone.dueDate}` : 'No due date'}
+        </div>
+      </section>
+    </MilestoneItem>
+  );
+};
+
+export default Milestone;

--- a/frontend/src/components/AsideMenu/MilestoneMenu/Milestone/style.js
+++ b/frontend/src/components/AsideMenu/MilestoneMenu/Milestone/style.js
@@ -1,0 +1,17 @@
+import styled from '@emotion/styled';
+
+export const MilestoneItem = styled.li`
+  width: 100%;
+  height: 3.5rem;
+  display: flex;
+
+  & .milestone-title {
+    font-size: 1.2rem;
+    color: #70767d;
+  }
+
+  & .milestone-duedate {
+    font-size: 0.9rem;
+    color: #b9bcbf;
+  }
+`;

--- a/frontend/src/components/AsideMenu/MilestoneMenu/index.jsx
+++ b/frontend/src/components/AsideMenu/MilestoneMenu/index.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import SideBox from '../../common/SideBox';
+import { useMainState } from '../../../contexts/MainContext';
+import Milestone from './Milestone';
+import Filter from '../../common/Filter';
+import useInputChange from '../../../hooks/useInputChange';
+import { MilestoneMenuContainer, MilestoneContainer } from './style';
+
+export const MilestoneMenu = ({ onClick, additionalInfo }) => {
+  return (
+    <MilestoneMenuContainer>
+      <section className='milestone-menu-title'>
+        <div className='title'>Milestone</div>
+        <div className='icon' onClick={onClick}>
+          <i className='fas fa-cog'></i>
+        </div>
+      </section>
+      <section className='milestone-menu-content'>
+        {additionalInfo.milestone ? (
+          <>
+            <div className='graph'></div>
+            <div className='milestone-menu-content-title'>
+              {additionalInfo.milestone.title}
+            </div>
+          </>
+        ) : (
+          <div>No milestone</div>
+        )}
+      </section>
+    </MilestoneMenuContainer>
+  );
+};
+
+export const MilestoneDropDown = ({ additionalInfo, setAdditionalInfo }) => {
+  const { milestones } = useMainState();
+  const [milestoneInput, changeMilestoneInput] = useInputChange('');
+
+  return (
+    <MilestoneContainer>
+      <div className='milestone_list_header'>Set milestone</div>
+      <Filter
+        value={milestoneInput}
+        onChange={changeMilestoneInput}
+        placeholder={'Filter milestones'}
+      />
+      <ul className='milestone_list_content'>
+        {milestones.map(milestone => (
+          <Milestone
+            key={milestone.id}
+            milestone={milestone}
+            setAdditionalInfo={setAdditionalInfo}
+            additionalInfo={additionalInfo}
+          />
+        ))}
+      </ul>
+    </MilestoneContainer>
+  );
+};

--- a/frontend/src/components/AsideMenu/MilestoneMenu/style.js
+++ b/frontend/src/components/AsideMenu/MilestoneMenu/style.js
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+
+export const MilestoneMenuContainer = styled.div`
+  & .milestone-menu-title {
+    display: flex;
+    justify-content: space-between;
+  }
+  & .title {
+    font-size: 1.1rem;
+    color: #70767d;
+  }
+
+  & .icon {
+    font-size: 1.1rem;
+    color: #9ca2aa;
+  }
+
+  & .milestone-menu-content {
+    & .graph {
+      height: 0.8rem;
+      background: #cccccc;
+      border-radius: 40px;
+    }
+    & .milestone-menu-content-title {
+      font-size: 1.1rem;
+      color: #70767d;
+    }
+  }
+`;
+
+export const MilestoneContainer = styled.ul`
+  width: 100%;
+
+  & .milestone_list_header {
+    height: 1.5rem;
+    background-color: #f7f8fa;
+  }
+
+  & .milestone_list_content {
+    list-style: none;
+    background-color: #fdfdfd;
+  }
+`;

--- a/frontend/src/components/NewIssue/InputSection/IssueAside.jsx
+++ b/frontend/src/components/NewIssue/InputSection/IssueAside.jsx
@@ -1,28 +1,64 @@
 import React from 'react';
 import SideBoxContainer from '../../common/SideBox';
+import { LabelMenu, LabelMenuDropDown } from '../../AsideMenu/LabelMenu.jsx';
+import {
+  AssigneeMenu,
+  AssigneeMenuDropDown
+} from '../../AsideMenu/AssigneeMenu.jsx';
+import {
+  MilestoneMenu,
+  MilestoneDropDown
+} from '../../AsideMenu/MilestoneMenu';
 
-const FirstChild = ({ onClick }) => {
+const IssueAside = ({ additionalInfo, setAdditionalInfo }) => {
   return (
     <>
-      <div className='title'>Assignees</div>
-      <div className='setting_btn' onClick={onClick}>
-        <i className='fas fa-cog'></i>
-      </div>
-      <div>Selected</div>
+      <SideBoxContainer
+        FirstChild={onClick => (
+          <AssigneeMenu
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+            onClick={onClick}
+          />
+        )}
+        SecondChild={
+          <AssigneeMenuDropDown
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+          />
+        }
+      />
+      <SideBoxContainer
+        FirstChild={onClick => (
+          <LabelMenu
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+            onClick={onClick}
+          />
+        )}
+        SecondChild={
+          <LabelMenuDropDown
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+          />
+        }
+      />
+      <SideBoxContainer
+        FirstChild={onClick => (
+          <MilestoneMenu
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+            onClick={onClick}
+          />
+        )}
+        SecondChild={
+          <MilestoneDropDown
+            additionalInfo={additionalInfo}
+            setAdditionalInfo={setAdditionalInfo}
+          />
+        }
+      />
     </>
-  );
-};
-
-const SecondChild = () => {
-  return <p>SECOND!!!</p>;
-};
-
-const IssueAside = () => {
-  return (
-    <SideBoxContainer
-      FirstChild={FirstChild}
-      SecondChild={SecondChild}
-    ></SideBoxContainer>
   );
 };
 

--- a/frontend/src/components/common/Filter.jsx
+++ b/frontend/src/components/common/Filter.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import styled from '@emotion/styled';
+
+const FilterContainer = styled.div`
+  display: flex;
+  width: 70%;
+  padding-left: 0.5rem;
+  border: 1px solid #e1e4e8;
+  border-top-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  align-items: center;
+
+  & input {
+    width: 100%;
+    height: 100%;
+    margin-left: 0.5rem;
+    padding-left: 0.5rem;
+    border-top-right-radius: 5px;
+    border-bottom-right-radius: 5px;
+    border: none;
+    &:focus {
+      outline: none;
+    }
+  }
+
+  &:focus-within {
+    box-shadow: 0 0 0 3px #88b8ff;
+  }
+`;
+
+const Filter = ({ value, onChange, placeholder }) => {
+  return (
+    <FilterContainer>
+      <input
+        type='text'
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}
+      />
+    </FilterContainer>
+  );
+};
+
+export default Filter;

--- a/frontend/src/components/common/SideBox.jsx
+++ b/frontend/src/components/common/SideBox.jsx
@@ -3,10 +3,11 @@ import styled from '@emotion/styled';
 
 const SideBoxWrapper = styled.div`
   position: relative;
-  background-color: lightblue;
-  border: 1px solid lightgrey;
-  height: 8vh;
-  width: 10%;
+  left: 10rem;
+  height: 6rem;
+  width: 20rem;
+  border-bottom: 1px solid lightgrey;
+  padding: 1rem 0rem;
 `;
 
 const SideBox = ({ children }) => {
@@ -15,8 +16,8 @@ const SideBox = ({ children }) => {
 
 const DropDownWrapper = styled.div`
   position: absolute;
-  top: 0;
-  right: 0;
+  top: 3rem;
+  left: 0;
   border: 1px solid lightgrey;
 `;
 
@@ -31,12 +32,8 @@ const SideBoxContainer = ({ FirstChild, SecondChild }) => {
 
   return (
     <SideBox>
-      <FirstChild onClick={toggleIsShow}></FirstChild>
-      {isShow && (
-        <DropDownBox>
-          <SecondChild></SecondChild>
-        </DropDownBox>
-      )}
+      {FirstChild(toggleIsShow)}
+      {isShow && <DropDownBox>{SecondChild}</DropDownBox>}
     </SideBox>
   );
 };

--- a/frontend/src/contexts/MainContext.jsx
+++ b/frontend/src/contexts/MainContext.jsx
@@ -22,7 +22,8 @@ export const ContextProvider = ({ children }) => {
     myInfo: {},
     issues: [],
     labels: [],
-    milestones: []
+    milestones: [],
+    joinUsers: []
   });
 
   return (


### PR DESCRIPTION
## 관련 이슈들
- ex: [#23](https://github.com/boostcamp-2020/IssueTracker-27/issues/23)

## 구현된 내용
- 각각의 사이드 메뉴(label, milestone, assignee) 구현
- 사이드 메뉴 기능
  - 메뉴의 톱니 바퀴를 클릭하면 drop down menu가 나타난다
  - drop down menu의 item을 클릭하면 선택된 것이 저장된다

## 미구현된 내용
- css styling
- 이미지 업로드

## 사진 (선택)
![image](https://user-images.githubusercontent.com/43084680/97959767-65604b00-1df3-11eb-8b39-b4bdd473bf9c.png)

